### PR TITLE
Fix non idiomatic go code

### DIFF
--- a/learning/Debugging/using-runtime.go
+++ b/learning/Debugging/using-runtime.go
@@ -6,13 +6,15 @@ import (
 	"strings"
 )
 
-func fileName(original string) string {
+func fileName(original string) []string {
 	i := strings.LastIndex(original, "/")
+	var result []string
 	if i == -1 {
-		return original
+		result = append(result, original)
 	} else {
-		return original[i+1:]
+		result = append(result, original[i+1:])
 	}
+	return result
 }
 
 func debugLog(msg string) {


### PR DESCRIPTION
The error seens was,
"if block ends with a return statement, so drop this else and outdent its block"

The change fixes it in indiomatic way.